### PR TITLE
[WIP] resource update / download

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ export class DatasetEditor extends React.Component {
     super(props);
     this.state = {
       dataset: this.props.config.dataset,
-      resource: this.props.config.dataset.resources[0] || {},
+      resource: typeof this.props.config.dataset.resources != "undefined"? this.props.config.dataset.resources[0] : {},
       datasetId: this.props.config.dataset.id,
       ui: {
         fileOrLink: "",
@@ -61,7 +61,7 @@ export class DatasetEditor extends React.Component {
   }
 
   mapResourceToDatapackageResource(fileResource) {
-    let datapackage = { ...this.state.dataset.metadata };
+    let datapackage = { ...this.state.dataset };
     let resource = {}
 
     resource["bytes"] = fileResource.size;
@@ -132,7 +132,7 @@ export class DatasetEditor extends React.Component {
   };
 
   downloadDatapackage = async () => {
-    let datapackage = { ...this.state.dataset.metadata };
+    let datapackage = { ...this.state.dataset };
     let resource = { ...datapackage.resources[0] };
     resource.schema.fields.forEach((f) => {
       f.type = f.columnType;
@@ -312,6 +312,24 @@ export class DatasetEditor extends React.Component {
           error => alert('Error on upload dataset'));
   };
 
+  setDatasetRes = (resource) => {
+    
+    let dataset = {...this.state.dataset};
+
+    if (typeof dataset.resources == "undefined") {
+      dataset["resources"] = []
+      dataset["resources"].push(resource)
+    }else {
+      dataset.resources.push(resource);
+    }
+    
+
+    this.setState({
+      dataset: dataset
+    });
+
+  }
+
   render() {
     const { success, loading } = this.state.ui;
     console.log(this.state.dataset.name)
@@ -346,6 +364,7 @@ export class DatasetEditor extends React.Component {
                 datasetId={this.state.datasetId}
                 handleUploadStatus={this.handleUploadStatus}
                 onChangeResourceId={this.onChangeResourceId}
+                setDataset={this.setDatasetRes}
                 organizationId={'gift-data'}
                 authToken={this.props.config.authToken}
                 lfsServerUrl={this.props.config.lfsServerUrl}

--- a/src/components/Upload/index.jsx
+++ b/src/components/Upload/index.jsx
@@ -131,6 +131,8 @@ class Upload extends React.Component {
       success: false,
     });
 
+    this.props.setDataset(resource.descriptor)
+
     client
       .upload(resource, organizationId, this.state.datasetId, this.onProgress)
       .then((response) => {
@@ -145,6 +147,8 @@ class Upload extends React.Component {
           loading: false,
           success: true,
         });
+
+        
       })
       .catch((error) => {
         console.error("Upload failed with error: " + error);

--- a/src/data1.json
+++ b/src/data1.json
@@ -1,0 +1,3 @@
+{
+    "id": "Test-Package"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const element = document.getElementById("ResourceEditor");
 if (element) {
   const config = {
     authorizedApi: "/api/authorize",
-    lfs: "https://localhost:6000", 
+    lfsServerUrl: "https://giftless-gift.herokuapp.com/", 
     dataset: data.default,
     metastoreApi: '/api/dataset'
   };


### PR DESCRIPTION
This pull request is not meant to be merge but to point out things. 

How do we create a `datapackage.json` for a dataset not having  datapackage.json in its github repo?

Let assume this a dummy object return from `metastore.fetch`  : `{id: "saffsfsfsa", name:name"}`. it contains no resources or the likes. Hence the `DatasetEditor` props is set like this:

```js
this.state = {
      dataset: this.props.config.dataset,
      resource: typeof this.props.config.dataset.resources != "undefined"? this.props.config.dataset.resources[0] : {},
      datasetId: this.props.config.dataset.id,
 ......
```
Now when the resource is uploaded to storage via `lfserver`, in the first workflow page; the `datapackage.json` needs to be updated with the resource being uploaded.

Updating the resource is not present (to my knowledge of the code) and this affecting `Datapackaging` downloading at the end of the Publisher workflow. so I added this to the code

```js
setDatasetRes = (resource) => {
    
    let dataset = {...this.state.dataset};

    if (typeof dataset.resources == "undefined") {
      dataset["resources"] = []
      dataset["resources"].push(resource)
    }else {
      dataset.resources.push(resource);
    }
    

    this.setState({
      dataset: dataset
    });

  }
```
This method is called inside the `Upload` component.

```js
const resource = data.open(selectedFile);
this.props.setDataset(resource.descriptor)
```

@risenW i don't know if this is the proper method to which `datapackage` format is to be generated inside publisher?
